### PR TITLE
wordsmith definition of landmark and landmark subtree

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -297,10 +297,10 @@ Cosignature:
 : A signature from either the CA or other cosigner, over some checkpoint or subtree.
 
 Landmark:
-: One of an infrequent subset of tree sizes that can be used to predistribute trusted subtrees to relying parties for landmark-relative certificates.
+: One of a sequence of tree sizes, infrequently chosen and used to calculate landmark subtrees for predistribution to relying parties.
 
 Landmark subtree:
-: A subtree determined by a landmark. Landmark subtrees are common points of reference between relying parties and landmark-relative certificates.
+: One of the (up to two) subtrees determined by an interval between two landmarks. Predistributed and used as the basis for landmark-relative certificates.
 
 Standalone certificate:
 : A certificate containing an inclusion proof to some subtree, and several cosignatures over that subtree.


### PR DESCRIPTION
Rationale: the previous definition said landmark subtrees were determined by a single landmark, which is imprecise. They're determined by the interval between two. Also, it's clarifying to know up front that there are commonly two subtrees per interval, not one as someone might guess.

Also rework the definition of landmark slightly to emphasize that they are meaningful primarily as members of a sequence.

This may clear up some confusion I had when first reading the spec, and have heard from others, about whether a landmark _is_ a subtree.