### PR TITLE
Remove unused definition from ASN.1 block

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1245,9 +1245,6 @@ ext-mtcCertificationAuthority EXTENSION ::= {
     CRITICALITY TRUE
 }
 
--- From draft-ietf-tls-trust-anchor-ids
-TrustAnchorID ::= RELATIVE-OID
-
 -- This is 2^64-1, the maximum possible serial number in this protocol.
 mtcMaxSerial INTEGER ::= 18446744073709551615
 


### PR DESCRIPTION
This is a remnant of when there was a cosigner ID in the structure. Now the cosigner ID is implicit from the CA name.