### PR TITLE
demo: Catch up to plants-05

### DIFF
--- a/demo/config.go
+++ b/demo/config.go
@@ -24,6 +24,7 @@ const (
 	VersionPlants01
 	VersionPlants02
 	VersionPlants04
+	VersionPlants05
 )
 
 func (v DraftVersion) String() string {
@@ -38,6 +39,8 @@ func (v DraftVersion) String() string {
 		return "plants-02"
 	case VersionPlants04:
 		return "plants-04"
+	case VersionPlants05:
+		return "plants-05"
 	}
 	panic(fmt.Sprintf("unknown version %d", v))
 }
@@ -67,6 +70,8 @@ func DraftVersionFromString(s string) (v DraftVersion, ok bool) {
 		return VersionPlants02, true
 	case "plants-04":
 		return VersionPlants04, true
+	case "plants-05":
+		return VersionPlants05, true
 
 	default:
 		return 0, false
@@ -150,9 +155,14 @@ type CosignerConfig struct {
 	PrivateKey         []byte
 }
 
+type SerialConfig struct {
+	Log   uint16
+	Index uint64
+}
+
 type CACertConfig struct {
 	CertConfigBase
-	MinSerial uint64
+	MinSerial, MaxSerial SerialConfig
 }
 
 type CertConfigBase struct {

--- a/demo/encode.go
+++ b/demo/encode.go
@@ -128,8 +128,10 @@ func addSubject(b *cryptobyte.Builder, entry *EntryConfig) {
 }
 
 type mtcCAInfo struct {
+	version   DraftVersion
 	cosigner  *Cosigner
 	minSerial uint64
+	maxSerial uint64
 }
 
 func addExtensions(b *cryptobyte.Builder, config *CertConfigBase, mtcCA *mtcCAInfo) {
@@ -242,6 +244,9 @@ func addExtensions(b *cryptobyte.Builder, config *CertConfigBase, mtcCA *mtcCAIn
 							}
 						})
 						seq.AddASN1Uint64(mtcCA.minSerial)
+						if mtcCA.version >= VersionPlants05 {
+							seq.AddASN1Uint64(mtcCA.maxSerial)
+						}
 					})
 				})
 			})
@@ -423,6 +428,15 @@ func CreateCACertificate(config *CAConfig, cosigner *Cosigner) ([]byte, error) {
 		return nil, err
 	}
 
+	if config.CACert.MinSerial.Index >= 1<<48 {
+		return nil, fmt.Errorf("invalid MinSerial index")
+	}
+	if config.CACert.MaxSerial.Index >= 1<<48 {
+		return nil, fmt.Errorf("invalid MaxSerial index")
+	}
+	minSerial := (uint64(config.CACert.MinSerial.Log) << 48) | config.CACert.MinSerial.Index
+	maxSerial := (uint64(config.CACert.MaxSerial.Log) << 48) | config.CACert.MaxSerial.Index
+
 	b := cryptobyte.NewBuilder(nil)
 	b.AddASN1(cbasn1.SEQUENCE, func(cert *cryptobyte.Builder) {
 		cert.AddASN1(cbasn1.SEQUENCE, func(tbs *cryptobyte.Builder) {
@@ -433,9 +447,12 @@ func CreateCACertificate(config *CAConfig, cosigner *Cosigner) ([]byte, error) {
 			addValidity(tbs, &config.CACert.CertConfigBase)
 			addX509Name(tbs, config.ID) // Subject
 			tbs.AddBytes(spki)
+
 			addExtensions(tbs, &config.CACert.CertConfigBase, &mtcCAInfo{
+				version:   config.Version,
 				cosigner:  cosigner,
-				minSerial: config.CACert.MinSerial,
+				minSerial: minSerial,
+				maxSerial: maxSerial,
 			})
 		})
 		addUnsignedSigAlg(cert)

--- a/demo/mtc.json
+++ b/demo/mtc.json
@@ -1,5 +1,5 @@
 {
-  "Version": "plants-04",
+  "Version": "plants-05",
   "ID": "32473.1",
   "LogNumber": 1,
   "Cosigners": [
@@ -28,7 +28,9 @@
     "NotBefore": "2020-01-01T00:00:00Z",
     "NotAfter": "2030-12-31T23:59:59Z",
     "IsCA": true,
-    "KeyUsage": ["CertSign"]
+    "KeyUsage": ["CertSign"],
+    "MinSerial": {"Log": 1, "Index": 0},
+    "MaxSerial": {"Log": 5, "Index": 281474976710655}
   },
   "Entries": [
     {


### PR DESCRIPTION
The only wire format change is a maxSerial field. In doing so, expand the JSON format a bit, because expressing log << 48 | index in decimal is unreadable. (It's a pity we can't express the index in hex with JSON but ah well.)