### PR TITLE
Change MTCSignature to SubtreeSignature

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1340,14 +1340,14 @@ opaque HashValue[HASH_SIZE];
 struct {
     TrustAnchorID cosigner_id;
     opaque signature<0..2^16-1>;
-} MTCSignature;
+} SubtreeSignature;
 
 struct {
     MTCLogEntryExtension extensions<0..2^16-1>;
     uint48 start;
     uint48 end;
     HashValue inclusion_proof<0..2^16-1>;
-    MTCSignature signatures<0..2^16-1>;
+    SubtreeSignature signatures<0..2^16-1>;
 } MTCProof;
 ~~~
 


### PR DESCRIPTION
This better represents what data the signature is computed over, aligns with the body text ("`signatures` contains the chosen subtree signatures"), and reduces confusion given that this field is contained within the object which ends up acting as the signature on an MTC.