### PR TITLE
Note where the 1.3.6.1.4.1.44363.47 OID arc came from

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -962,7 +962,7 @@ For initial experimentation, early implementations of this design will:
 
 1. Use UTF8String to represent the attribute's value rather than RELATIVE-OID. The UTF8String contains trust anchor ID's ASCII representation, e.g. `32473.1`.
 
-1. Use the OID 1.3.6.1.4.1.44363.47.1 instead of `id-rdna-trustAnchorID`.
+1. Use the OID 1.3.6.1.4.1.44363.47.1 instead of `id-rdna-trustAnchorID`. Cloudflare has kindly donated the 1.3.6.1.4.1.44363.47 OID arc for use in this document.
 
 For example, the distinguished name for a CA with ID `32473.1` would be represented in syntax of {{?RFC4514}} as:
 
@@ -1207,7 +1207,7 @@ MTCCertificationAuthority ::= SEQUENCE {
 }
 ~~~
 
-For initial experimentation, early implementations of this design will use the OID 1.3.6.1.4.1.44363.47.2 instead of `id-pe-mtcCertificationAuthority`.
+For initial experimentation, early implementations of this design will use the OID 1.3.6.1.4.1.44363.47.2 instead of `id-pe-mtcCertificationAuthority`. Cloudflare has kindly donated the 1.3.6.1.4.1.44363.47 OID arc for use in this document.
 
 The fields of an MTCCertificationAuthority structure are defined as follows:
 
@@ -1256,7 +1256,7 @@ id-alg-mtcProof OBJECT IDENTIFIER ::= {
     mechanisms(5) pkix(7) algorithms(6) TBD }
 ~~~
 
-For initial experimentation, early implementations of this design will use the OID 1.3.6.1.4.1.44363.47.0 instead of `id-alg-mtcProof`.
+For initial experimentation, early implementations of this design will use the OID 1.3.6.1.4.1.44363.47.0 instead of `id-alg-mtcProof`. Cloudflare has kindly donated the 1.3.6.1.4.1.44363.47 OID arc for use in this document.
 
 The `signatureValue` contains an MTCProof structure, defined below using the TLS presentation language ({{Section 3 of !RFC9846}}):
 


### PR DESCRIPTION
Folks seem to be mistakenly assuming 44363 is somehow the OID arc for CA or cosigner IDs. (For those, our examples always use 32473 from RFC 5612, though of course real deployments should use your own PENs.)