### PR TITLE
demo: Use uint64 for tree indices

### DIFF
--- a/demo/config.go
+++ b/demo/config.go
@@ -203,7 +203,7 @@ type CertificateConfig struct {
 	// are zero-indexed, but there is always a null entry at zero, so they are
 	// effectively one-indexed.)
 	// If Checkpoint is used, the named checkpoint sequence is used.
-	SubtreeStart, SubtreeEnd int
+	SubtreeStart, SubtreeEnd uint64
 	Checkpoint               string
 	// Must refer to a cosigner defined in the CAConfig.
 	Cosigners []TrustAnchorID

--- a/demo/cosign.go
+++ b/demo/cosign.go
@@ -159,7 +159,7 @@ func NewCosignerFromConfig(version DraftVersion, config *CosignerConfig) (*Cosig
 	}, nil
 }
 
-func (c *Cosigner) Sign(logID TrustAnchorID, start, end int, hash *HashValue) ([]byte, error) {
+func (c *Cosigner) Sign(logID TrustAnchorID, start, end uint64, hash *HashValue) ([]byte, error) {
 	b := cryptobyte.NewBuilder(nil)
 	if c.Version >= VersionPlants04 {
 		b.AddBytes([]byte("subtree/v1\n\x00"))
@@ -178,8 +178,8 @@ func (c *Cosigner) Sign(logID TrustAnchorID, start, end int, hash *HashValue) ([
 	if !IsValidSubtree(start, end) {
 		return nil, fmt.Errorf("invalid subtree")
 	}
-	b.AddUint64(uint64(start))
-	b.AddUint64(uint64(end))
+	b.AddUint64(start)
+	b.AddUint64(end)
 	b.AddBytes((*hash)[:])
 	inp, err := b.Bytes()
 	if err != nil {

--- a/demo/encode.go
+++ b/demo/encode.go
@@ -339,7 +339,7 @@ func LogID(config *CAConfig) TrustAnchorID {
 	return logID
 }
 
-func CreateCertificate(config *CAConfig, issuanceLog *MerkleTree, cosigners []*Cosigner, entry *EntryConfig, certConfig *CertificateConfig, index, start, end int) ([]byte, error) {
+func CreateCertificate(config *CAConfig, issuanceLog *MerkleTree, cosigners []*Cosigner, entry *EntryConfig, certConfig *CertificateConfig, index, start, end uint64) ([]byte, error) {
 	if entry.Null {
 		return nil, errors.New("cannot construct certificate for null entry")
 	}
@@ -347,7 +347,7 @@ func CreateCertificate(config *CAConfig, issuanceLog *MerkleTree, cosigners []*C
 	logID := LogID(config)
 	b := cryptobyte.NewBuilder(nil)
 	b.AddASN1(cbasn1.SEQUENCE, func(cert *cryptobyte.Builder) {
-		serial := uint64(index)
+		serial := index
 		if config.Version >= VersionPlants04 {
 			if serial > 1<<48-1 {
 				cert.SetError(fmt.Errorf("invalid serial: %d", index))
@@ -383,11 +383,11 @@ func CreateCertificate(config *CAConfig, issuanceLog *MerkleTree, cosigners []*C
 			}
 			addEmptyMTCEntryExtensions(certSig, config.Version)
 			if config.Version >= VersionPlants04 {
-				certSig.AddUint48(uint64(start))
-				certSig.AddUint48(uint64(end))
+				certSig.AddUint48(start)
+				certSig.AddUint48(end)
 			} else {
-				certSig.AddUint64(uint64(start))
-				certSig.AddUint64(uint64(end))
+				certSig.AddUint64(start)
+				certSig.AddUint64(end)
 			}
 			certSig.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) { child.AddBytes(proof) })
 			certSig.AddUint16LengthPrefixed(func(cosigs *cryptobyte.Builder) {

--- a/demo/log.go
+++ b/demo/log.go
@@ -36,15 +36,15 @@ func HashNode(left, right *HashValue) HashValue {
 	return ret
 }
 
-func IsValidSubtree(start, end int) bool {
+func IsValidSubtree(start, end uint64) bool {
 	if 0 > start || start > end {
 		return false
 	}
 	if start == end {
 		return true
 	}
-	ceil := uint(1) << (bits.UintSize - bits.LeadingZeros(uint(end-start-1)))
-	return uint(start)&(ceil-1) == 0
+	ceil := uint64(1) << (64 - bits.LeadingZeros64(end-start-1))
+	return start&(ceil-1) == 0
 }
 
 type MerkleTree struct {
@@ -75,9 +75,9 @@ func NewMerkleTree(entries [][]byte) *MerkleTree {
 	return log
 }
 
-func (mt *MerkleTree) Size() int { return len(mt.levels[0]) }
+func (mt *MerkleTree) Size() uint64 { return uint64(len(mt.levels[0])) }
 
-func (mt *MerkleTree) SubtreeHash(start, end int) (HashValue, error) {
+func (mt *MerkleTree) SubtreeHash(start, end uint64) (HashValue, error) {
 	if !IsValidSubtree(start, end) {
 		return HashValue{}, fmt.Errorf("invalid subtree: [%d, %d)", start, end)
 	}
@@ -89,7 +89,7 @@ func (mt *MerkleTree) SubtreeHash(start, end int) (HashValue, error) {
 	}
 	// Start at the largest complete subtree on the right edge.
 	last := end - 1
-	level := bits.TrailingZeros(^uint(last - start))
+	level := bits.TrailingZeros64(^last - start)
 	start >>= level
 	last >>= level
 	ret := mt.levels[level][last]
@@ -106,7 +106,7 @@ func (mt *MerkleTree) SubtreeHash(start, end int) (HashValue, error) {
 	return ret, nil
 }
 
-func (mt *MerkleTree) SubtreeInclusionProof(index, start, end int) ([]byte, error) {
+func (mt *MerkleTree) SubtreeInclusionProof(index, start, end uint64) ([]byte, error) {
 	if !IsValidSubtree(start, end) {
 		return nil, fmt.Errorf("invalid subtree: [%d, %d)", start, end)
 	}
@@ -141,7 +141,7 @@ func (mt *MerkleTree) SubtreeInclusionProof(index, start, end int) ([]byte, erro
 	return proof, nil
 }
 
-func (mt *MerkleTree) SubtreeConsistencyProof(start, end, n int) ([]byte, error) {
+func (mt *MerkleTree) SubtreeConsistencyProof(start, end, n uint64) ([]byte, error) {
 	if !IsValidSubtree(start, end) {
 		return nil, fmt.Errorf("invalid subtree: [%d, %d)", start, end)
 	}
@@ -161,7 +161,7 @@ func (mt *MerkleTree) SubtreeConsistencyProof(start, end, n int) ([]byte, error)
 // known) over the tree's entries, with the subtree and window described in
 // absolute indices. known reports whether the subtree hash is already known to
 // the verifier and so may be omitted from the proof.
-func (mt *MerkleTree) subtreeSubproof(start, end, lo, hi int, known bool) ([]byte, error) {
+func (mt *MerkleTree) subtreeSubproof(start, end, lo, hi uint64, known bool) ([]byte, error) {
 	if start == lo && end == hi {
 		// The subtree is the whole window.
 		if known {
@@ -175,10 +175,10 @@ func (mt *MerkleTree) subtreeSubproof(start, end, lo, hi int, known bool) ([]byt
 	}
 	// The window has more than one element, so split it at the largest power
 	// of two smaller than its size.
-	k := 1 << (bits.Len(uint(hi-lo-1)) - 1)
+	k := uint64(1) << (bits.Len64(hi-lo-1) - 1)
 	split := lo + k
 	var proof []byte
-	var siblingStart, siblingEnd int
+	var siblingStart, siblingEnd uint64
 	var err error
 	switch {
 	case end <= split:
@@ -208,7 +208,7 @@ func (mt *MerkleTree) subtreeSubproof(start, end, lo, hi int, known bool) ([]byt
 	return append(proof, h[:]...), nil
 }
 
-func SubtreesForInterval(start, end int) (start1, end1, start2, end2 int, err error) {
+func SubtreesForInterval(start, end uint64) (start1, end1, start2, end2 uint64, err error) {
 	if 0 > start || start > end {
 		err = fmt.Errorf("invalid interval [%d, %d)", start, end)
 		return
@@ -223,12 +223,12 @@ func SubtreesForInterval(start, end int) (start1, end1, start2, end2 int, err er
 	last := end - 1
 	// Find where start and last's tree paths diverge. The two
 	// subtrees will be on either side of the split.
-	split := bits.Len(uint(start^last)) - 1
-	mask := (1 << split) - 1
+	split := bits.Len64(start^last) - 1
+	mask := (uint64(1) << split) - 1
 	mid := last & ^mask
 	// Maximize the left endpoint. This is just before start's
 	// path leaves the right edge of its new subtree.
-	leftSplit := bits.Len(uint(^start & mask))
+	leftSplit := bits.Len64(^start & mask)
 	start1 = start & ^((1 << leftSplit) - 1)
 	end1 = mid
 	start2 = mid

--- a/demo/log_test.go
+++ b/demo/log_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func evaluateSubtreeInclusionProof(index, start, end int, entryHash *HashValue, proof []byte) (HashValue, error) {
+func evaluateSubtreeInclusionProof(index, start, end uint64, entryHash *HashValue, proof []byte) (HashValue, error) {
 	if !IsValidSubtree(start, end) {
 		return HashValue{}, fmt.Errorf("invalid subtree")
 	}
@@ -53,7 +53,7 @@ func TestMerkleTree(t *testing.T) {
 	}
 	tree := NewMerkleTree(entries)
 
-	for end := 1; end <= numEntries; end++ {
+	for end := uint64(1); end <= numEntries; end++ {
 		// Try all subtrees ending at `end`.
 		for level := range depth {
 			start := ((end - 1) >> level) << level
@@ -84,9 +84,9 @@ func TestMerkleTree(t *testing.T) {
 
 func TestSubtreesForInterval(t *testing.T) {
 	var tests = []struct {
-		start, end   int
-		start1, end1 int
-		start2, end2 int
+		start, end   uint64
+		start1, end1 uint64
+		start2, end2 uint64
 	}{
 		{start: 9, end: 9, start1: 9, end1: 9, start2: 9, end2: 9},
 		{start: 8, end: 9, start1: 8, end1: 9, start2: 9, end2: 9},

--- a/demo/main.go
+++ b/demo/main.go
@@ -24,7 +24,7 @@ var (
 type certificateInfo struct {
 	entryConfig       *EntryConfig
 	certConfig        *CertificateConfig
-	index, start, end int
+	index, start, end uint64
 	cosigners         []*Cosigner
 	// The number of certificate for the given index.
 	num int
@@ -113,14 +113,14 @@ func do() error {
 	// awaiting an end value once the next checkpoint in the sequence is
 	// allocated.
 	type checkpointWait struct {
-		idx  int
-		prev int
+		idx  uint64
+		prev uint64
 	}
 	awaitingCheckpoint := map[string][]checkpointWait{}
 	// Maps checkpoint sequence name to the latest checkpoint size.
 	// Initially, all sequences are at zero, which matches the default map
 	// lookup behavior.
-	checkpointSeqs := map[string]int{}
+	checkpointSeqs := map[string]uint64{}
 	for entryConfigIdx := range config.Entries {
 		entryConfig := &config.Entries[entryConfigIdx]
 		repeat := 1
@@ -133,7 +133,7 @@ func do() error {
 				return err
 			}
 			entries = append(entries, entry)
-			entryIdx := len(entries) - 1
+			entryIdx := uint64(len(entries) - 1)
 
 			// Schedule certificates.
 			for certNum := range entryConfig.Certificates {
@@ -147,7 +147,7 @@ func do() error {
 					info.end = certConfig.SubtreeEnd
 				} else if c := certConfig.Checkpoint; len(c) != 0 {
 					// Make a note to fill in the subtree when available.
-					awaitingCheckpoint[c] = append(awaitingCheckpoint[c], checkpointWait{idx: len(certInfos), prev: checkpointSeqs[c]})
+					awaitingCheckpoint[c] = append(awaitingCheckpoint[c], checkpointWait{idx: uint64(len(certInfos)), prev: checkpointSeqs[c]})
 				} else {
 					return fmt.Errorf("neither Checkpoint nor SubtreeEnd specified in a certificate")
 				}
@@ -169,13 +169,13 @@ func do() error {
 
 			// Update checkpoint sequences.
 			for _, seq := range entryConfig.Checkpoints {
-				checkpointSeqs[seq] = len(entries)
+				checkpointSeqs[seq] = uint64(len(entries))
 				// Fill in any certificate infos that are still awaiting
 				// a checkpoint.
 				for _, wait := range awaitingCheckpoint[seq] {
 					// We have the checkpoint interval. Find the two subtrees
 					// and use the one that includes the certificate.
-					start1, end1, start2, end2, err := SubtreesForInterval(wait.prev, len(entries))
+					start1, end1, start2, end2, err := SubtreesForInterval(wait.prev, uint64(len(entries)))
 					if err != nil {
 						return err
 					}
@@ -274,7 +274,7 @@ func do() error {
 		}
 	}
 
-	checkpointHash, err := issuanceLog.SubtreeHash(0, len(entries))
+	checkpointHash, err := issuanceLog.SubtreeHash(0, uint64(len(entries)))
 	if err != nil {
 		panic(err)
 	}
@@ -283,7 +283,7 @@ func do() error {
 	fmt.Fprintf(&signedNote, "%d\n", len(entries))
 	fmt.Fprintf(&signedNote, "%s\n\n", base64.StdEncoding.EncodeToString(checkpointHash[:]))
 	for _, cosigner := range cosigners {
-		cosig, err := cosigner.Sign(LogID(&config), 0, len(entries), &checkpointHash)
+		cosig, err := cosigner.Sign(LogID(&config), 0, uint64(len(entries)), &checkpointHash)
 		if err != nil {
 			return err
 		}

--- a/demo/vectors_test.go
+++ b/demo/vectors_test.go
@@ -38,8 +38,8 @@ func writeProofLine(w io.Writer, prefix string, proof []byte) {
 func TestSubtreeHashVectors(t *testing.T) {
 	tree := subtreeVectorTree()
 	h := sha256.New()
-	for end := 0; end <= subtreeVectorMax; end++ {
-		for start := 0; start <= end; start++ {
+	for end := uint64(0); end <= subtreeVectorMax; end++ {
+		for start := uint64(0); start <= end; start++ {
 			if !IsValidSubtree(start, end) {
 				continue
 			}
@@ -59,8 +59,8 @@ func TestSubtreeHashVectors(t *testing.T) {
 func TestSubtreeInclusionProofVectors(t *testing.T) {
 	tree := subtreeVectorTree()
 	h := sha256.New()
-	for end := 0; end <= subtreeVectorMax; end++ {
-		for start := 0; start <= end; start++ {
+	for end := uint64(0); end <= subtreeVectorMax; end++ {
+		for start := uint64(0); start <= end; start++ {
 			if !IsValidSubtree(start, end) {
 				continue
 			}
@@ -82,9 +82,9 @@ func TestSubtreeInclusionProofVectors(t *testing.T) {
 func TestSubtreeConsistencyProofVectors(t *testing.T) {
 	tree := subtreeVectorTree()
 	h := sha256.New()
-	for n := 0; n <= subtreeVectorMax; n++ {
-		for end := 0; end <= n; end++ {
-			for start := 0; start <= end; start++ {
+	for n := uint64(0); n <= subtreeVectorMax; n++ {
+		for end := uint64(0); end <= n; end++ {
+			for start := uint64(0); start <= end; start++ {
 				if !IsValidSubtree(start, end) {
 					continue
 				}
@@ -104,8 +104,8 @@ func TestSubtreeConsistencyProofVectors(t *testing.T) {
 
 func TestEfficientCoveringSubtreeVectors(t *testing.T) {
 	h := sha256.New()
-	for end := 0; end <= subtreeVectorMax; end++ {
-		for start := 0; start <= end; start++ {
+	for end := uint64(0); end <= subtreeVectorMax; end++ {
+		for start := uint64(0); start <= end; start++ {
 			start1, end1, start2, end2, err := SubtreesForInterval(start, end)
 			if err != nil {
 				t.Fatalf("SubtreesForInterval(%d, %d): %v", start, end, err)


### PR DESCRIPTION
int is a fine type when we're building a tree (the tree fits in memory), but when we're verifying certificates, we should represent the full range of possible values.

Preparation for #283.