### PR TITLE
Fix X.690 reference

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -50,7 +50,7 @@ author:
 
 normative:
   X.690:
-    title: "Information technology - ASN.1 encoding Rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
+    title: "Information technology - ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
     date: February 2021
     author:
       org: ITU-T

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -51,6 +51,7 @@ author:
 normative:
   X.690:
     title: "Information technology - ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
+    target: https://www.itu.int/rec/T-REC-X.690
     date: February 2021
     author:
       org: ITU-T

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -55,7 +55,7 @@ normative:
     author:
       org: ITU-T
     seriesinfo:
-      ISO/IEC 8824-1:2021
+      ISO/IEC 8825-1:2021
 
   # For the ASN.1 module
   RFC5912:

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -56,7 +56,7 @@ normative:
     author:
       org: ITU-T
     seriesinfo:
-      ISO/IEC 8825-1:2021
+      ISO/IEC: 8825-1:2021
 
   # For the ASN.1 module
   RFC5912:


### PR DESCRIPTION
Four small fixes to the X.690 normative reference, one commit each:

1. **`ISO/IEC 8824-1:2021` → `8825-1:2021`.** 8824-1 is X.680, the ASN.1 *notation*. X.690, the *encoding rules*, is 8825-1.
2. **`encoding Rules` → `encoding rules`,** matching ITU-T's own capitalization.
3. **Add a `target` URL.** X.690 was the only non-RFC reference without one.
4. **Split the seriesinfo into name and value.** The bare scalar form emitted `name="ISO/IEC 8824-1:2021" value=""`; the empty value renders as a stray space before the comma.

Result:

    -          (DER)", ISO/IEC 8824-1:2021 , February 2021.
    +          (DER)", ISO/IEC 8825-1:2021, February 2021,
    +          <https://www.itu.int/rec/T-REC-X.690>.