### PR TITLE
Clarify impact of shorter-lived certificates

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -214,7 +214,7 @@ Current signature schemes can use as few as 32 bytes per key and 64 bytes per si
 
 This increased overhead additionally impacts CT logs themselves. Most of a log's costs scale with the total storage size of the log. Each log entry contains both a public key, and a signature from the CA. With larger public keys and signatures, the size of each log entry will grow.
 
-Additionally, as PKIs transition to shorter-lived certificates {{CABF-153}} {{CABF-SC081}}, the number of entries in the log will grow.
+Additionally, as PKIs transition to shorter-lived certificates {{CABF-153}} {{CABF-SC081}}, the rate at which entries are added to the log will increase.
 
 This document introduces Merkle Tree Certificates (MTCs), a new form of X.509 certificate that integrates logging with certificate issuance. Each CA maintains logs of everything it issues, signing views of its logs to assert it has issued the contents. The CA signature is combined with cosignatures from other parties who verify correct operation and optionally mirror the logs. These signatures, together with an inclusion proof for an individual entry, constitute a certificate.
 


### PR DESCRIPTION
The issuance log is append-only, so its entry count grows regardless of certificate lifetimes. What shorter lifetimes actually change is how quickly entries accumulate, since certificates are renewed more often. Reword the Introduction accordingly to refer to the rate at which entries are added rather than to the number of entries.