### PR TITLE
Cite RFC 9925 instead of draft-ietf-lamps-x509-alg-none

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1922,7 +1922,7 @@ IANA is requested to add the following entry to the "SMI Security for PKIX Certi
 
 ## Relative Distinguished Name Attribute
 
-IANA is requested to add the following entry to the "SMI Security for PKIX Relative Distinguished Name Attribute" registry {{?I-D.ietf-lamps-x509-alg-none}}:
+IANA is requested to add the following entry to the "SMI Security for PKIX Relative Distinguished Name Attribute" registry {{!RFC9925}}:
 
 | Decimal | Description           | References |
 |---------|-----------------------|------------|


### PR DESCRIPTION
The LAMPS draft that defined the "SMI Security for PKIX Relative Distinguished Name Attribute" registry has since been published as RFC 9925, and idnits flags the draft reference as stale. Point the IANA section at the RFC. The document already cites RFC 9925 normatively when describing unsigned certificates, so use the same normative form here.