### PR TITLE
Say what the issuance process diverges from

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -373,7 +373,7 @@ Merkle Tree Certificates are issued as follows. {{fig-issuance-overview}} depict
 
 1. The authenticating party requests a certificate, e.g. over ACME {{?RFC8555}}
 
-2. The CA validates each incoming issuance request, e.g. with ACME challenges. From there, the process differs.
+2. The CA validates each incoming issuance request, e.g. with ACME challenges. From there, the process diverges from CT-based PKIs.
 
 3. The CA operates a series of append-only *issuance logs* ({{issuance-logs}}). Unlike a CT log, these logs only contain entries added by the CA:
 


### PR DESCRIPTION
Editorial only; no normative changes.

Step 2 of the issuance overview ended with "From there, the process differs", without saying what it differs from.

The intended contrast is with Certificate Transparency, drawn in the first paragraph of the section:

> In Certificate Transparency, a CA first certifies information by signing it, then submits the resulting certificate (or precertificate) to logs for logging. Merkle Tree Certificates invert this process ...

That paragraph is separated from the numbered list by the issuance architecture figure, so a reader arriving at the list from the "Merkle Tree Certificates are issued as follows" lead-in no longer has the comparison in view. Locally, the list describes a single process, so "the process differs" invites being read as differing between deployments or depending on something established in step 2. Step 3 then opens with "Unlike a CT log ...", which supplies the comparator retroactively, but step 2 should not need step 3 to be unambiguous.

This names the comparison and uses "diverges" rather than "differs". "Diverge" presupposes a shared path up to the point of divergence, so it also conveys that the first two steps are unchanged from existing issuance, which is the other half of the point the sentence is making.
