### PR TITLE
Specify the landmark publication format precisely

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1371,11 +1371,13 @@ To ensure that only active landmarks contain unexpired certificates, set `max_ac
 
 CAs SHOULD publish their active landmarks, so that relying parties can configure trusted subtrees ({{trusted-subtrees}}). The following format can be used to describe this information. The format is the following sequence of lines. Each line MUST be terminated by a newline character (U+000A):
 
-* Two space-separated non-negative decimal integers: `<last_landmark> <num_active_landmarks>`.
+* Two non-negative decimal integers, separated by a single space character (U+0020) and represented without leading zeros: `<last_landmark> <num_active_landmarks>`.
   This line MUST satisfy the following, otherwise it is invalid:
   * `num_active_landmarks <= max_active_landmarks`
   * `num_active_landmarks <= last_landmark`
-* `num_active_landmarks + 1` lines each containing a single non-negative decimal integer, representing a tree size. Numbered from zero to `num_active_landmarks`, line `i` contains the tree size for landmark `last_landmark - i`. The tree sizes MUST be strictly monotonically decreasing and less than or equal to the log's latest tree size.
+* `num_active_landmarks + 1` lines, each containing a tree size as a non-negative decimal integer without leading zeros. Numbered from zero to `num_active_landmarks`, line `i` contains the tree size for landmark `last_landmark - i`. The tree sizes MUST be strictly monotonically decreasing and less than or equal to the log's latest tree size.
+
+Landmark numbers and tree sizes are both at most 2<sup>48</sup>-1 ({{issuance-logs}}). Any deviation from this format, including additional whitespace or any content following the final line, makes the document invalid. Relying parties MUST reject an invalid document in its entirety, rather than acting on the portion that precedes the error.
 
 It is RECOMMENDED that this format be published as an HTTP resource {{!RFC9110}} with content type `text/plain; charset=utf-8`.
 

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -255,6 +255,8 @@ uint8 uint48[6];
 
 `U+` followed by four hexadecimal characters denotes a Unicode codepoint, to be encoded in UTF-8 {{!RFC3629}}. `0x` followed by two hexadecimal characters denotes a byte value in the 0-255 range.
 
+The *decimal representation* of a non-negative integer is its base-ten representation, written with the ASCII digits `0` through `9` (U+0030 through U+0039). Zero is written as the single digit `0`, and no other value is written with a leading `0`.
+
 `[start, end)`, where `start <= end`, denotes the half-open interval containing integers `x` such that `start <= x < end`.
 
 Given a non-negative integer `n`,
@@ -1371,11 +1373,11 @@ To ensure that only active landmarks contain unexpired certificates, set `max_ac
 
 CAs SHOULD publish their active landmarks, so that relying parties can configure trusted subtrees ({{trusted-subtrees}}). The following format can be used to describe this information. The format is the following sequence of lines. Each line MUST be terminated by a newline character (U+000A):
 
-* Two non-negative decimal integers, separated by a single space character (U+0020) and represented without leading zeros: `<last_landmark> <num_active_landmarks>`.
+* The decimal representations of two non-negative integers, separated by a single space character (U+0020): `<last_landmark> <num_active_landmarks>`.
   This line MUST satisfy the following, otherwise it is invalid:
   * `num_active_landmarks <= max_active_landmarks`
   * `num_active_landmarks <= last_landmark`
-* `num_active_landmarks + 1` lines, each containing a tree size as a non-negative decimal integer without leading zeros. Numbered from zero to `num_active_landmarks`, line `i` contains the tree size for landmark `last_landmark - i`. The tree sizes MUST be strictly monotonically decreasing and less than or equal to the log's latest tree size.
+* `num_active_landmarks + 1` lines, each containing the decimal representation of a tree size. Numbered from zero to `num_active_landmarks`, line `i` contains the tree size for landmark `last_landmark - i`. The tree sizes MUST be strictly monotonically decreasing and less than or equal to the log's latest tree size.
 
 Landmark numbers and tree sizes are both at most 2<sup>48</sup>-1 ({{issuance-logs}}). Any deviation from this format, including additional whitespace or any content following the final line, makes the document invalid. Relying parties MUST reject an invalid document in its entirety, rather than acting on the portion that precedes the error.
 


### PR DESCRIPTION
The landmark publication format is fetched by relying parties from CAs, so
two implementations that parse it differently is an interoperability
problem rather than a local matter. The description was looser than the
surrounding text, which pins the line terminator to "a newline character
(U+000A)" and, in the test vector appendix, the separator to "a space
(U+0020)".

This makes the first line's separator exactly one U+0020, rules out
leading zeros on both lines, states the range of the values, and says what
"invalid" obliges a relying party to do.

The 2^48-1 bound is not a new constraint: landmark zero has tree size zero
and tree sizes are strictly monotonically increasing, so a landmark number
never exceeds its tree size, which Section 5.2 already caps at 2^48-1.

The second bullet is also reworded slightly to avoid "integer,
representing a tree size" reading awkwardly once "without leading zeros"
is added.
